### PR TITLE
enable ta signing

### DIFF
--- a/recipes-security/optee/optee-os-stm32mp_%.bbappend
+++ b/recipes-security/optee/optee-os-stm32mp_%.bbappend
@@ -3,3 +3,5 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI += "file://0001-plat-stm32mp1-enable-stack-unwinding.patch \
             file://0002-plat-stm32mp1-enable-BSEC-write-capabilities.patch \
             "
+
+EXTRA_OEMAKE += "TA_PUBLIC_KEY=${TA_CUSTOM_PUBKEY}"


### PR DESCRIPTION
enable ta signing by passing to optee-os the path to the custom public key to use for validating TAs